### PR TITLE
Add the max segments size 

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -55,4 +55,4 @@ jobs:
         flake8 . --count --show-source --statistics
     - name: Test with pytest
       run: |
-        pytest --cov-report=xml --cov=sms_toolkit tests
+        pytest -vv --cov-report=xml --cov=sms_toolkit tests

--- a/sms_toolkit/messages/profiling.py
+++ b/sms_toolkit/messages/profiling.py
@@ -30,6 +30,9 @@ def profile_message(message, is_for_mms=False):
             utils.encode_unicode_character_to_utf16,
         )
         message_length = sum(len(list(segment['byte_groups'])) for segment in segments)
+        max_segment_size = constants.MMS_MAX_SEGMENT_SIZE if len(segments) <= 1 \
+            else constants.MMS_MAX_CONCAT_SEGMENT_SIZE
+
     elif encoding == constants.GSM_ENCODING:
         segments = split_message_into_segments(
             message,
@@ -38,6 +41,9 @@ def profile_message(message, is_for_mms=False):
             utils.encode_unicode_character_to_gsm,
         )
         message_length = sum(len(segment['byte_groups']) for segment in segments)
+        max_segment_size = constants.GSM_MAX_SEGMENT_SIZE if len(segments) <= 1 \
+            else constants.GSM_MAX_CONCAT_SEGMENT_SIZE
+
     elif encoding == constants.UCS2_ENCODING:
         segments = split_message_into_segments(
             message,
@@ -46,6 +52,10 @@ def profile_message(message, is_for_mms=False):
             utils.encode_unicode_character_to_utf16,
         )
         message_length = sum(len(utils.flatten(segment['byte_groups'])) for segment in segments) // 2
+        max_segment_size = constants.UCS2_MAX_SEGMENT_SIZE if len(segments) <= 1 \
+            else constants.UCS2_MAX_CONCAT_SEGMENT_SIZE
+        max_segment_size = max_segment_size // 2
+
     else:
         raise RuntimeError('Unknown encoding: {encoding}'.format(encoding=encoding))
 
@@ -53,6 +63,7 @@ def profile_message(message, is_for_mms=False):
         'num_segments': len(segments),
         'segments': segments,
         'message_length': message_length,
+        'max_segment_size': max_segment_size,
     }
 
 

--- a/sms_toolkit/messages/profiling.py
+++ b/sms_toolkit/messages/profiling.py
@@ -101,6 +101,7 @@ def split_message_into_segments(message, max_segment_size, max_concat_segment_si
             except IndexError:
                 return current_length
 
+        segment_str = ''
         while len(characters) > 0 and get_next_character_length() <= max_concat_segment_size:
             character = characters.pop(0)
 
@@ -114,8 +115,9 @@ def split_message_into_segments(message, max_segment_size, max_concat_segment_si
 
             if byte_group is not None:
                 current_length += len(byte_group)
+            segment_str += character
 
-        segments.append(format_segment(message, segment_characters, segment_byte_groups))
+        segments.append(format_segment(segment_str, segment_characters, segment_byte_groups))
 
     return segments
 

--- a/tests/test_message_segmenting.py
+++ b/tests/test_message_segmenting.py
@@ -1,5 +1,5 @@
 from sms_toolkit.messages import profiling
-
+from sms_toolkit import constants
 
 class TestMessageSegmenting:
     def test_message_profiling_gsm7(self, short_gsm7_text, long_gsm7_text, byte_string_gsm7_chars, unicode_gsm7_chars):
@@ -7,32 +7,38 @@ class TestMessageSegmenting:
         assert profiled_message["num_segments"] == 1
         assert profiled_message["message_length"] == 11
         assert len(profiled_message["segments"]) == 1
+        assert profiled_message["max_segment_size"] == constants.GSM_MAX_SEGMENT_SIZE
 
         profiled_message = profiling.profile_message(long_gsm7_text)
         assert profiled_message["num_segments"] == 3
         assert profiled_message["message_length"] == 329
         assert len(profiled_message["segments"]) == 3
+        assert profiled_message["max_segment_size"] == constants.GSM_MAX_CONCAT_SEGMENT_SIZE
 
         profiled_message = profiling.profile_message(unicode_gsm7_chars)
         assert profiled_message["num_segments"] == 1
         assert profiled_message["message_length"] == 106
         assert len(profiled_message["segments"]) == 1
+        assert profiled_message["max_segment_size"] == constants.GSM_MAX_SEGMENT_SIZE
 
         profiled_message = profiling.profile_message(byte_string_gsm7_chars)
         assert profiled_message["num_segments"] == 1
         assert profiled_message["message_length"] == 106
         assert len(profiled_message["segments"]) == 1
+        assert profiled_message["max_segment_size"] == constants.GSM_MAX_SEGMENT_SIZE
 
     def test_message_profiling_ucs2(self, short_ucs2_text, long_ucs2_text):
         profiled_message = profiling.profile_message(short_ucs2_text)
         assert profiled_message["num_segments"] == 1
         assert profiled_message["message_length"] == 14
         assert len(profiled_message["segments"]) == 1
+        assert profiled_message["max_segment_size"] == (constants.UCS2_MAX_SEGMENT_SIZE // 2)
 
         profiled_message = profiling.profile_message(long_ucs2_text)
         assert profiled_message["num_segments"] == 5
         assert profiled_message["message_length"] == 334
         assert len(profiled_message["segments"]) == 5
+        assert profiled_message["max_segment_size"] == (constants.UCS2_MAX_CONCAT_SEGMENT_SIZE // 2)
 
     def test_message_profiling_mms_gsm7(self, short_gsm7_text, long_gsm7_text, byte_string_gsm7_chars,
                                         unicode_gsm7_chars):
@@ -40,29 +46,35 @@ class TestMessageSegmenting:
         assert profiled_message["num_segments"] == 1
         assert profiled_message["message_length"] == 11
         assert len(profiled_message["segments"]) == 1
+        assert profiled_message["max_segment_size"] == constants.MMS_MAX_SEGMENT_SIZE
 
         profiled_message = profiling.profile_message(long_gsm7_text, is_for_mms=True)
         assert profiled_message["num_segments"] == 1
         assert profiled_message["message_length"] == 329
         assert len(profiled_message["segments"]) == 1
+        assert profiled_message["max_segment_size"] == constants.MMS_MAX_SEGMENT_SIZE
 
         profiled_message = profiling.profile_message(unicode_gsm7_chars, is_for_mms=True)
         assert profiled_message["num_segments"] == 1
         assert profiled_message["message_length"] == 106
         assert len(profiled_message["segments"]) == 1
+        assert profiled_message["max_segment_size"] == constants.MMS_MAX_SEGMENT_SIZE
 
         profiled_message = profiling.profile_message(byte_string_gsm7_chars, is_for_mms=True)
         assert profiled_message["num_segments"] == 1
         assert profiled_message["message_length"] == 106
         assert len(profiled_message["segments"]) == 1
+        assert profiled_message["max_segment_size"] == constants.MMS_MAX_SEGMENT_SIZE
 
     def test_message_profiling_mms_ucs2(self, short_ucs2_text, long_ucs2_text):
         profiled_message = profiling.profile_message(short_ucs2_text, is_for_mms=True)
         assert profiled_message["num_segments"] == 1
         assert profiled_message["message_length"] == 14
         assert len(profiled_message["segments"]) == 1
+        assert profiled_message["max_segment_size"] == constants.MMS_MAX_SEGMENT_SIZE
 
         profiled_message = profiling.profile_message(long_ucs2_text, is_for_mms=True)
         assert profiled_message["num_segments"] == 1
         assert profiled_message["message_length"] == 334
         assert len(profiled_message["segments"]) == 1
+        assert profiled_message["max_segment_size"] == constants.MMS_MAX_SEGMENT_SIZE

--- a/tests/test_message_segmenting.py
+++ b/tests/test_message_segmenting.py
@@ -1,6 +1,7 @@
 from sms_toolkit.messages import profiling
 from sms_toolkit import constants
 
+
 class TestMessageSegmenting:
     def test_message_profiling_gsm7(self, short_gsm7_text, long_gsm7_text, byte_string_gsm7_chars, unicode_gsm7_chars):
         profiled_message = profiling.profile_message(short_gsm7_text)


### PR DESCRIPTION
## Add a "max_segment_size" field in the response
- For GSM7, if message has 1 segment, the max-size is 160, but if it's greater, then it's 153. 
- This needs to be sent in the segmentation body for the client to use as necessary.
- The same logic applies for UCS2 too
- Added tests to fix this

## Fix the message in the segment body
- Right now, we are sending the entire original message inside every segment.
- We need to be adding whatever is the right segment. It is super useful when debugging.
- NOTE: I added some tests initially, but the equality comparisons in the tests are causing issues with py2 and py3. I'm tracking and debugging this in [a separate branch](https://github.com/chrisconlon-klaviyo/sms-toolkit/tree/fix/message-segments-test) (It's getting a bit ugly TBH), but in the interest of the time I am not including it in this PR.

## Make the pytest output verbose
- If the pytest fails, it's output is not sufficient to debug anything. Added -vv to make it verbose.
