### PR TITLE
Make the total_segment_length UCS2 aware

### DIFF
--- a/sms_toolkit/messages/profiling.py
+++ b/sms_toolkit/messages/profiling.py
@@ -132,7 +132,7 @@ def format_segment(message, unicode_characters, byte_groups, is_utf16):
                                                   characters.
             byte_groups          (list of bytes): The message split into byte groups
                                                   for each character.
-            is_ucs2                    (boolean): If the message is in ucs2 encoding
+            is_utf16                   (boolean): If the message is in utf-16 encoding
     """
     total_segment_length = len(utils.flatten(byte_groups))
     if is_utf16:

--- a/sms_toolkit/messages/profiling.py
+++ b/sms_toolkit/messages/profiling.py
@@ -79,6 +79,7 @@ def split_message_into_segments(message, max_segment_size, max_concat_segment_si
     """
     segments = []
     characters = utils.convert_to_unicode_characters(message)
+    is_ucs2 = encoder == utils.encode_unicode_character_to_utf16
 
     if len(characters) == 0:
         return segments
@@ -87,7 +88,7 @@ def split_message_into_segments(message, max_segment_size, max_concat_segment_si
     total_num_bytes = len(utils.flatten(byte_groups))
 
     if total_num_bytes <= max_segment_size:
-        segments.append(format_segment(message, characters, byte_groups))
+        segments.append(format_segment(message, characters, byte_groups, is_ucs2))
         return segments
 
     while len(characters) > 0:
@@ -117,12 +118,12 @@ def split_message_into_segments(message, max_segment_size, max_concat_segment_si
                 current_length += len(byte_group)
             segment_str += character
 
-        segments.append(format_segment(segment_str, segment_characters, segment_byte_groups))
+        segments.append(format_segment(segment_str, segment_characters, segment_byte_groups, is_ucs2))
 
     return segments
 
 
-def format_segment(message, unicode_characters, byte_groups):
+def format_segment(message, unicode_characters, byte_groups, is_ucs2):
     """ Formats a segment's properties.
 
         Args:
@@ -131,10 +132,14 @@ def format_segment(message, unicode_characters, byte_groups):
                                                   characters.
             byte_groups          (list of bytes): The message split into byte groups
                                                   for each character.
+            is_ucs2                    (boolean): If the message is in ucs2 encoding
     """
+    total_segment_length = len(utils.flatten(byte_groups))
+    if is_ucs2:
+        total_segment_length = total_segment_length // 2
     return {
         'message': message,
         'unicode_character_list': unicode_characters,
         'byte_groups': byte_groups,
-        'total_segment_length': len(utils.flatten(byte_groups)),
+        'total_segment_length': total_segment_length,
     }

--- a/sms_toolkit/messages/profiling.py
+++ b/sms_toolkit/messages/profiling.py
@@ -79,7 +79,7 @@ def split_message_into_segments(message, max_segment_size, max_concat_segment_si
     """
     segments = []
     characters = utils.convert_to_unicode_characters(message)
-    is_ucs2 = encoder == utils.encode_unicode_character_to_utf16
+    is_utf16 = encoder == utils.encode_unicode_character_to_utf16
 
     if len(characters) == 0:
         return segments
@@ -88,7 +88,7 @@ def split_message_into_segments(message, max_segment_size, max_concat_segment_si
     total_num_bytes = len(utils.flatten(byte_groups))
 
     if total_num_bytes <= max_segment_size:
-        segments.append(format_segment(message, characters, byte_groups, is_ucs2))
+        segments.append(format_segment(message, characters, byte_groups, is_utf16))
         return segments
 
     while len(characters) > 0:
@@ -118,12 +118,12 @@ def split_message_into_segments(message, max_segment_size, max_concat_segment_si
                 current_length += len(byte_group)
             segment_str += character
 
-        segments.append(format_segment(segment_str, segment_characters, segment_byte_groups, is_ucs2))
+        segments.append(format_segment(segment_str, segment_characters, segment_byte_groups, is_utf16))
 
     return segments
 
 
-def format_segment(message, unicode_characters, byte_groups, is_ucs2):
+def format_segment(message, unicode_characters, byte_groups, is_utf16):
     """ Formats a segment's properties.
 
         Args:
@@ -135,7 +135,7 @@ def format_segment(message, unicode_characters, byte_groups, is_ucs2):
             is_ucs2                    (boolean): If the message is in ucs2 encoding
     """
     total_segment_length = len(utils.flatten(byte_groups))
-    if is_ucs2:
+    if is_utf16:
         total_segment_length = total_segment_length // 2
     return {
         'message': message,

--- a/tests/test_message_segmenting.py
+++ b/tests/test_message_segmenting.py
@@ -3,30 +3,51 @@ from sms_toolkit import constants
 
 
 class TestMessageSegmenting:
+    @staticmethod
+    def assert_segment_lengths_for_profiled_message(profiled_message, expected_total_segment_lengths):
+        for i, segment in enumerate(profiled_message["segments"]):
+            assert expected_total_segment_lengths[i] == segment["total_segment_length"]
+
     def test_message_profiling_gsm7(self, short_gsm7_text, long_gsm7_text, byte_string_gsm7_chars, unicode_gsm7_chars):
         profiled_message = profiling.profile_message(short_gsm7_text)
         assert profiled_message["num_segments"] == 1
         assert profiled_message["message_length"] == 11
         assert len(profiled_message["segments"]) == 1
         assert profiled_message["max_segment_size"] == constants.GSM_MAX_SEGMENT_SIZE
+        self.assert_segment_lengths_for_profiled_message(
+            profiled_message,
+            expected_total_segment_lengths=[11]
+        )
 
         profiled_message = profiling.profile_message(long_gsm7_text)
         assert profiled_message["num_segments"] == 3
         assert profiled_message["message_length"] == 329
         assert len(profiled_message["segments"]) == 3
         assert profiled_message["max_segment_size"] == constants.GSM_MAX_CONCAT_SEGMENT_SIZE
+        self.assert_segment_lengths_for_profiled_message(
+            profiled_message,
+            expected_total_segment_lengths=[153, 153, 23]
+        )
 
         profiled_message = profiling.profile_message(unicode_gsm7_chars)
         assert profiled_message["num_segments"] == 1
         assert profiled_message["message_length"] == 106
         assert len(profiled_message["segments"]) == 1
         assert profiled_message["max_segment_size"] == constants.GSM_MAX_SEGMENT_SIZE
+        self.assert_segment_lengths_for_profiled_message(
+            profiled_message,
+            expected_total_segment_lengths=[106]
+        )
 
         profiled_message = profiling.profile_message(byte_string_gsm7_chars)
         assert profiled_message["num_segments"] == 1
         assert profiled_message["message_length"] == 106
         assert len(profiled_message["segments"]) == 1
         assert profiled_message["max_segment_size"] == constants.GSM_MAX_SEGMENT_SIZE
+        self.assert_segment_lengths_for_profiled_message(
+            profiled_message,
+            expected_total_segment_lengths=[106]
+        )
 
     def test_message_profiling_ucs2(self, short_ucs2_text, long_ucs2_text):
         profiled_message = profiling.profile_message(short_ucs2_text)
@@ -34,12 +55,20 @@ class TestMessageSegmenting:
         assert profiled_message["message_length"] == 14
         assert len(profiled_message["segments"]) == 1
         assert profiled_message["max_segment_size"] == (constants.UCS2_MAX_SEGMENT_SIZE // 2)
+        self.assert_segment_lengths_for_profiled_message(
+            profiled_message,
+            expected_total_segment_lengths=[14]
+        )
 
         profiled_message = profiling.profile_message(long_ucs2_text)
         assert profiled_message["num_segments"] == 5
         assert profiled_message["message_length"] == 334
         assert len(profiled_message["segments"]) == 5
         assert profiled_message["max_segment_size"] == (constants.UCS2_MAX_CONCAT_SEGMENT_SIZE // 2)
+        self.assert_segment_lengths_for_profiled_message(
+            profiled_message,
+            expected_total_segment_lengths=[67, 67, 67, 67, 66]
+        )
 
     def test_message_profiling_mms_gsm7(self, short_gsm7_text, long_gsm7_text, byte_string_gsm7_chars,
                                         unicode_gsm7_chars):
@@ -48,24 +77,40 @@ class TestMessageSegmenting:
         assert profiled_message["message_length"] == 11
         assert len(profiled_message["segments"]) == 1
         assert profiled_message["max_segment_size"] == constants.MMS_MAX_SEGMENT_SIZE
+        self.assert_segment_lengths_for_profiled_message(
+            profiled_message,
+            expected_total_segment_lengths=[11]
+        )
 
         profiled_message = profiling.profile_message(long_gsm7_text, is_for_mms=True)
         assert profiled_message["num_segments"] == 1
         assert profiled_message["message_length"] == 329
         assert len(profiled_message["segments"]) == 1
         assert profiled_message["max_segment_size"] == constants.MMS_MAX_SEGMENT_SIZE
+        self.assert_segment_lengths_for_profiled_message(
+            profiled_message,
+            expected_total_segment_lengths=[329]
+        )
 
         profiled_message = profiling.profile_message(unicode_gsm7_chars, is_for_mms=True)
         assert profiled_message["num_segments"] == 1
         assert profiled_message["message_length"] == 106
         assert len(profiled_message["segments"]) == 1
         assert profiled_message["max_segment_size"] == constants.MMS_MAX_SEGMENT_SIZE
+        self.assert_segment_lengths_for_profiled_message(
+            profiled_message,
+            expected_total_segment_lengths=[106]
+        )
 
         profiled_message = profiling.profile_message(byte_string_gsm7_chars, is_for_mms=True)
         assert profiled_message["num_segments"] == 1
         assert profiled_message["message_length"] == 106
         assert len(profiled_message["segments"]) == 1
         assert profiled_message["max_segment_size"] == constants.MMS_MAX_SEGMENT_SIZE
+        self.assert_segment_lengths_for_profiled_message(
+            profiled_message,
+            expected_total_segment_lengths=[106]
+        )
 
     def test_message_profiling_mms_ucs2(self, short_ucs2_text, long_ucs2_text):
         profiled_message = profiling.profile_message(short_ucs2_text, is_for_mms=True)
@@ -73,9 +118,17 @@ class TestMessageSegmenting:
         assert profiled_message["message_length"] == 14
         assert len(profiled_message["segments"]) == 1
         assert profiled_message["max_segment_size"] == constants.MMS_MAX_SEGMENT_SIZE
+        self.assert_segment_lengths_for_profiled_message(
+            profiled_message,
+            expected_total_segment_lengths=[14]
+        )
 
         profiled_message = profiling.profile_message(long_ucs2_text, is_for_mms=True)
         assert profiled_message["num_segments"] == 1
         assert profiled_message["message_length"] == 334
         assert len(profiled_message["segments"]) == 1
         assert profiled_message["max_segment_size"] == constants.MMS_MAX_SEGMENT_SIZE
+        self.assert_segment_lengths_for_profiled_message(
+            profiled_message,
+            expected_total_segment_lengths=[334]
+        )


### PR DESCRIPTION
## Background
Since the logic for the estimation is being moved to the backend, the client would require the last segment's size. This is already being added in the `total_segment_length` property in every segment, which can be used for that exact purpose.

But the problem here is that the total-segment-length was returning the total number bytes in the segment. When using GSM-7, every character is 1 byte, but in the case of UCS-2 every character is 2 bytes. The value returned by total-segment-length needs to account for the encoding and return the correct value when either of the encodings are used.

## Changes
Add different calculation for `total-segment-length` depending on what the encoding being used is. 
NOTE: `total-segment-length` is not being used by app currently, by will be used after this change is released.

## Tests
Updated the tests to reflect this

## Examples
## OLD INCORRECT BEHAVIOUR
Input string - `I like this 😀 and this 😂 and this 😶'`

Output (Look at `total_segment_length`)
```python
{'num_segments': 1,
 'segments': [{'message': 'I like this 😀 and this 😂 and this 😶',
   'unicode_character_list': ['I'...],
   'byte_groups': [...],
   'total_segment_length': 70
  }],
 'message_length': 35,
 'max_segment_size': 70
}
```

## NEW BEHAVIOUR
Input string - `I like this 😀 and this 😂 and this 😶'`

Output (Look at `total_segment_length`)
```python
{
 'num_segments': 1,
 'segments': [{'message': 'I like this 😀 and this 😂 and this 😶',
   'unicode_character_list': ['I'...],
   'byte_groups': [...],
   'total_segment_length': 35
  }],
 'message_length': 35,
 'max_segment_size': 70
}
```