### PR TITLE
remove python2 support, add 3.10

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -13,14 +13,14 @@ setup(
     packages=find_packages(),
     package_data={'': ['README.rst']},
     classifiers=[
-        "Programming Language :: Python :: 2.7",
         "Programming Language :: Python :: 3",
         "Programming Language :: Python :: 3.5",
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.10",
         "Operating System :: OS Independent",
         "Topic :: Software Development :: Libraries :: Python Modules"
     ],
-    python_requires='>=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, <4',
+    python_requires='>=3, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, <4',
 )


### PR DESCRIPTION
No functional change, tests pass on 3.10. To prevent python version regressions though, we are removing 2.7 support.